### PR TITLE
Aguirre -> Quepos

### DIFF
--- a/data/csv/adm2-cantones.csv
+++ b/data/csv/adm2-cantones.csv
@@ -68,7 +68,7 @@ Código,Provincia,Nombre,Área (km2),Pop. (2008)
 603,6,Buenos Aires,2384.22,47576
 604,6,Montes de Oro,244.76,12495
 605,6,Osa,1930.24,29547
-606,6,Aguirre,543.77,23915
+606,6,Quepos,543.77,23915
 607,6,Golfito,1753.96,39699
 608,6,Coto Brus,933.91,47247
 609,6,Parrita,478.79,13940

--- a/data/json/adm2-cantones.json
+++ b/data/json/adm2-cantones.json
@@ -415,7 +415,7 @@
 	},
 	"606": {
 		"Provincia": "6",
-		"Nombre": "Aguirre",
+		"Nombre": "Quepos",
 		"Área (km2)": "543.77",
 		"Pop. (2008)": "23915"
 	},


### PR DESCRIPTION
Según expediente 19.236: Cambio de Denominación del Cantón VI, Aguirre,
de la Provincia de Puntarenas, para que en Adelante se Denomine Quepos
http://www.asamblea.go.cr/Actas/2014-2015-PLENARIO-SESI%C3%93N-136.pdf
